### PR TITLE
merge: ERT:011- User Management tab opens multiple times

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -15,6 +15,7 @@ class Dashboard(DashboardViews):
         self.root.configure(bg="#FAF3E1")
         self._proc_archive = None
         self._win_analytics = None
+        self._win_user_mgmt = None
         self._build_layout()
         self.show_daily_sales()
 
@@ -114,9 +115,13 @@ class Dashboard(DashboardViews):
         TransactionAnalyticsApp(self._win_analytics)
 
     def open_user_management(self):
+        if self._win_user_mgmt and tk.Toplevel.winfo_exists(self._win_user_mgmt):
+            self._win_user_mgmt.lift()
+            self._win_user_mgmt.focus_force()
+            return
         from user_management import UserManagement
-        win = tk.Toplevel(self.root)
-        UserManagement(win)
+        self._win_user_mgmt = tk.Toplevel(self.root)
+        UserManagement(self._win_user_mgmt)
 
     def logout_and_redirect(self):
         try:

--- a/src/sales_archive.py
+++ b/src/sales_archive.py
@@ -38,8 +38,13 @@ class SalesArchive:
         self.root.title("Sales Archive - Chizzling POS")
         self.root.geometry("1000x650")
         self.root.configure(bg="#FAF3E1")
+        self.root.update_idletasks()
+        sw = self.root.winfo_screenwidth()
+        sh = self.root.winfo_screenheight()
+        self.root.geometry(f"1000x650+{(sw-1000)//2}+{(sh-650)//2}")
         _ensure_archive_tables()
         self._build_ui()
+        self._load_archived(auto=True)
 
     def _build_ui(self):
         # Header
@@ -135,8 +140,6 @@ class SalesArchive:
         vsb.pack(side="right", fill="y")
 
     def _load_archived(self, auto=False):
-        if auto:
-            return
         self.tree.delete(*self.tree.get_children())
         conn = connect_db()
         with conn:

--- a/src/user_management.py
+++ b/src/user_management.py
@@ -11,6 +11,10 @@ class UserManagement:
         self.root.title("User Management")
         self.root.geometry("700x500")
         self.root.configure(bg="#FAF3E1")
+        self.root.update_idletasks()
+        sw = self.root.winfo_screenwidth()
+        sh = self.root.winfo_screenheight()
+        self.root.geometry(f"700x500+{(sw-700)//2}+{(sh-500)//2}")
         self._build_ui()
         self.load_users()
 


### PR DESCRIPTION
fix: center User Management and Sales Archive windows on open

- Add screen centering logic to UserManagement using winfo_screenwidth/height
- Add screen centering logic to SalesArchive using winfo_screenwidth/height
- Fix _load_archived skipping initial data load due to leftover auto flag